### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a monorepo with two components:
+
+- **`CamDigitalProfile/`** — Static HTML/CSS/JS portfolio site (no build step). Serve with any static server (e.g. `npx serve -l 3000 CamDigitalProfile`).
+- **`agent-backend/`** — Node.js (ESM) Express API on port 8787 with a LangChain.js ReAct agent (Google Gemini + tools).
+
+### Required secrets
+
+- `GEMINI_API_KEY` — required for chat and document embeddings.
+- `TAVILY_API_KEY` — required for the `web_search` tool; the agent degrades gracefully without it.
+
+These must be available as environment variables. The backend reads them from a repo-root `.env` file (path `../.env` relative to `agent-backend/`). Create `.env` at the workspace root:
+
+```
+GEMINI_API_KEY=<value>
+TAVILY_API_KEY=<value>
+```
+
+### Running services
+
+| Service | Command | Port | Notes |
+|---|---|---|---|
+| Agent backend | `cd agent-backend && npm run dev` | 8787 | Warms knowledge-base embedding index at startup |
+| Static frontend | `npx serve -l 3000 CamDigitalProfile` | 3000 | Chat UI posts to `http://localhost:8787/api/agent/chat` |
+
+### Testing commands (from `agent-backend/`)
+
+| Command | What it does | API key needed? |
+|---|---|---|
+| `npm test` | Unit/regression tests (memory, vector ranking, agent graph, source guards) | No |
+| `npm run test:integration` | Live Gemini embedding sanity check (skips gracefully if key is missing) | Yes |
+| `npm run smoke` | HTTP health check — requires server running first | No |
+
+### Non-obvious caveats
+
+- The `.env` file must be at the **repo root** (not inside `agent-backend/`). The config reads `../.env` relative to its own directory.
+- The knowledge-base embedding index warms asynchronously on server startup. If a `knowledge_base` query arrives before warming completes, it may return fewer results.
+- Calculator tool queries may return `"I could not produce a response."` even when the tool executes correctly — this is an existing behavior in the agent's answer extraction, not an environment issue.
+- There is no linter configured in this project (no ESLint, Prettier, or similar).
+- There is no build step — the backend runs directly via `node src/server.js` and the frontend is plain HTML.
+- See `README.md` and `CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md` for full env var reference and API contracts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,6 @@ TAVILY_API_KEY=<value>
 
 - The `.env` file must be at the **repo root** (not inside `agent-backend/`). The config reads `../.env` relative to its own directory.
 - The knowledge-base embedding index warms asynchronously on server startup. If a `knowledge_base` query arrives before warming completes, it may return fewer results.
-- Calculator tool queries may return `"I could not produce a response."` even when the tool executes correctly — this is an existing behavior in the agent's answer extraction, not an environment issue.
 - There is no linter configured in this project (no ESLint, Prettier, or similar).
 - There is no build step — the backend runs directly via `node src/server.js` and the frontend is plain HTML.
 - See `README.md` and `CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md` for full env var reference and API contracts.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions so future agents can set up and run the project correctly.

## What's included

- **Required secrets** — `GEMINI_API_KEY` and `TAVILY_API_KEY` with `.env` placement instructions
- **Service startup** — Backend (`npm run dev` on port 8787) and static frontend (`npx serve` on port 3000)
- **Testing commands** — Unit tests, integration tests, and smoke check reference
- **Non-obvious caveats** — `.env` must be at repo root, knowledge-base warm-up behavior, no linter/build step

## Verification

The development environment was fully set up and all three agent tools verified end-to-end:

| Check | Result |
|---|---|
| `npm install` (agent-backend) | 129 packages installed |
| `npm test` (unit tests) | All passed |
| `npm run test:integration` (Gemini embeddings) | Passed |
| `npm run smoke` (health check) | `{"ok": true}` |
| `knowledge_base` tool | Answered questions about Cameron's background |
| `web_search` tool (Tavily) | Retrieved live AWS Lambda pricing info |
| `calculator` tool | Correctly computed 50,000 * 3% = 1,500 |
| Frontend chat UI | Working end-to-end in browser |

### Demo

[hello_world_chat_demo.mp4](https://cursor.com/agents/bc-dced345e-530e-4c5a-a5d7-4ad4c7d01fc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_chat_demo.mp4)

Asked "What project best demonstrates DevOps experience?" in the chat UI — agent used knowledge_base to respond with detailed DevOps project info.

[Hello world chat response](https://cursor.com/agents/bc-dced345e-530e-4c5a-a5d7-4ad4c7d01fc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_devops_response.webp)

### API test log

[hello_world_api_tests.log](https://cursor.com/agents/bc-dced345e-530e-4c5a-a5d7-4ad4c7d01fc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_api_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dced345e-530e-4c5a-a5d7-4ad4c7d01fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dced345e-530e-4c5a-a5d7-4ad4c7d01fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

