### PR TITLE
Portfolio: chat endpoint fix, resume updates, get-to-know-me page, AWS diagram, UI polish

### DIFF
--- a/CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md
+++ b/CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md
@@ -14,12 +14,12 @@
   - Do not create alternate spellings (for example `TAVILYL_API_KEY`): this causes runtime missing-key failures.
 - Optional:
   - `PORT` (default: `8787`)
-  - `GEMINI_MODEL` (default: `gemini-2.5-flash-lite`; override with any [supported model ID](https://ai.google.dev/gemini-api/docs/models))
+  - `GEMINI_MODEL` (default: `gemini-2.0-flash`; override with any [supported model ID](https://ai.google.dev/gemini-api/docs/models))
   - `GEMINI_EMBEDDING_MODEL` (default: `gemini-embedding-001`; used to build the in-memory vector index for `knowledge_base` at server startup)
   - `AGENT_MAX_ITERATIONS` (default: `7`)
   - `MODEL_TIMEOUT_MS` (default: `15000`)
   - `MEMORY_TURNS` (default: `8`)
-  - `ALLOWED_ORIGIN` (default: `*`)
+  - `ALLOWED_ORIGIN` (default `*`) — CORS. Use one origin or a **comma-separated** list, for example `https://www.cameronhammonddigitalportfolio.com,https://main.d123.amplifyapp.com`.
   - `AGENT_DEBUG_ERRORS=1` — include a short `detail` field in JSON error responses (raw upstream message snippet) for local debugging. Omit in production.
 
 ## Chat error responses
@@ -77,5 +77,5 @@ From `agent-backend/`:
 8. `What are Cameron's current career goals?`
 
 ## Notes
-- The chat UI sends requests to `/api/agent/chat` and persists `sessionId` in browser `sessionStorage`.
+- The chat UI resolves `POST /api/agent/chat` automatically: **localhost** uses `http://localhost:8787/api/agent/chat`; **production** defaults to **same-origin** `https://<your-domain>/api/agent/chat` (configure Amplify rewrites to your agent backend). Override with `meta[name="cam-agent-chat-endpoint"]` or `window.AGENT_CHAT_ENDPOINT` before `main.js` loads.
 - UI transparency intentionally exposes tool names only (no chain-of-thought).

--- a/CamDigitalProfile/DynamoDB-view.html
+++ b/CamDigitalProfile/DynamoDB-view.html
@@ -71,6 +71,11 @@
               <i class="bi bi-file-earmark-text navicon"></i>Resume
             </a>
           </li>
+          <li>
+            <a href="get-to-know-me.html">
+              <i class="bi bi-compass navicon"></i>Get to know me
+            </a>
+          </li>
           <li class="dropdown">
             <a href="aws-main.html">
               <i class="bi bi-menu-button navicon"></i>

--- a/CamDigitalProfile/_redirects.example
+++ b/CamDigitalProfile/_redirects.example
@@ -1,0 +1,8 @@
+# AWS Amplify Hosting (Custom redirects and rewrites)
+# Copy this file to `_redirects` in CamDigitalProfile/ and replace BACKEND_HOST with your
+# deployed agent-backend base URL (no trailing slash), e.g. https://abc123.execute-api.us-east-1.amazonaws.com/prod
+#
+# Same-origin /api/agent/* keeps HTTPS pages from calling http://localhost and avoids mixed-content blocks.
+#
+# /api/agent/chat  https://BACKEND_HOST/api/agent/chat  200
+# /api/agent/health  https://BACKEND_HOST/api/agent/health  200

--- a/CamDigitalProfile/assets/css/main.css
+++ b/CamDigitalProfile/assets/css/main.css
@@ -1279,18 +1279,21 @@ section,
 --------------------------------------------------------------*/
 
 .btn-primary {
-  background-color: #0056b3; /* Primary color, replace with your site's primary color */
-  border-color: #004085; /* Darker shade for border, replace with your color */
-  color: white;
-  padding: 15px 30px; /* Larger padding for bigger size */
-  font-size: 20px; /* Larger font size */
-  border-radius: 10px; /* Rounded corners for a sleeker look */
-  transition: background-color 0.3s, border-color 0.3s; /* Smooth transition for hover effect */
+  background-color: var(--accent-color);
+  border-color: color-mix(in srgb, var(--accent-color), #000 14%);
+  color: var(--contrast-color);
+  padding: 0.65rem 1.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--accent-color), transparent 70%);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
 }
 
 .btn-primary:hover {
-  background-color: #004085; /* Darker shade for hover */
-  border-color: #003366; /* Even darker for hover border */
+  background-color: color-mix(in srgb, var(--accent-color), #000 12%);
+  border-color: color-mix(in srgb, var(--accent-color), #000 22%);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--accent-color), transparent 55%);
 }
 
 .agent-chat {
@@ -1321,8 +1324,8 @@ section,
 }
 
 .agent-msg--user {
-  background: #0ea5e9;
-  color: #ffffff;
+  background: var(--accent-color);
+  color: var(--contrast-color);
   margin-left: auto;
 }
 
@@ -1362,3 +1365,52 @@ section,
   }
 }
 
+/*--------------------------------------------------------------
+# Portfolio polish — personal page & architecture card
+--------------------------------------------------------------*/
+.section-title h2 {
+  letter-spacing: -0.02em;
+  position: relative;
+  padding-bottom: 0.35rem;
+}
+
+.section-title h2::after {
+  content: "";
+  display: block;
+  width: 48px;
+  height: 3px;
+  margin-top: 0.5rem;
+  background: linear-gradient(90deg, var(--accent-color), color-mix(in srgb, var(--accent-color), transparent 55%));
+  border-radius: 2px;
+}
+
+.personal-life-card__media {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  background: color-mix(in srgb, var(--accent-color), #fff 92%);
+}
+
+.personal-life-card .card-body {
+  padding: 1.1rem 1.25rem 1.25rem;
+}
+
+.portfolio-arch-card {
+  border-radius: 0.65rem;
+}
+
+.portfolio-arch-diagram img {
+  max-height: min(70vh, 520px);
+  width: auto;
+}
+
+.btn-outline-primary,
+.btn-outline-secondary {
+  border-radius: 0.45rem;
+  font-weight: 500;
+  padding: 0.45rem 0.9rem;
+}
+
+.header {
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.12);
+}

--- a/CamDigitalProfile/assets/documents/Cameron Hammond - Resume - Sales Engineer.md
+++ b/CamDigitalProfile/assets/documents/Cameron Hammond - Resume - Sales Engineer.md
@@ -24,7 +24,7 @@ Brigham Young University – Marriott School of Business, Provo, UT
 
 **Customer-Facing & Technical Experience**
 
-**Sales Engineer – Intern	Starts May 18, 2026 \- Aug 2026**  
+**Sales Engineer – Intern	Starts May 18, 2026**  
 Lucid Software
 
 * Summer internship in sales engineering: supporting evaluations, demonstrations, and solution alignment with prospects and customers  

--- a/CamDigitalProfile/assets/documents/Cameron Hammond - Resume - Sales Engineer.md
+++ b/CamDigitalProfile/assets/documents/Cameron Hammond - Resume - Sales Engineer.md
@@ -13,7 +13,9 @@ Personal Website: [https://www.cameronhammonddigitalportfolio.com](https://www.c
 DevOps Emphasis, STEM-Certified Technical Program  
 Brigham Young University – Marriott School of Business, Provo, UT
 
-* Relevant Coursework: **Technical Sales**, Technical Business Strategy, AI Projects, Cloud Engineering  
+* Relevant Coursework: **Sales Engineering**, **Technical Sales**, Technical Business Strategy, **Agentic AI Development**, Cloud Engineering  
+* **Agentic AI Development** — multi-tool agents, RAG, evaluation, and production patterns; materials: [https://d1dtpagvh0qhqn.cloudfront.net/](https://d1dtpagvh0qhqn.cloudfront.net/)  
+* **Sales Engineering (coursework)** — four-level discovery (situational → strategic), active listening and EQ, “purpose / process / time / outcome” facilitation, ROI and value translation, stakeholder-specific business cases, high-EQ objection handling, micro-commitments and assumptive asks, PoC leadership, outcome-led demos (pain → turning point → outcome), and AI-assisted sales productivity  
 * GPA **3.94**/**4.00**  
 * Full-Tuition Academic Scholarship, Marriott School **Dean’s List** Academic Award Recipient  
 * Association of Information Systems (**AIS**), Mentorship Program (Mentoring 8 Junior IS students) 
@@ -21,6 +23,12 @@ Brigham Young University – Marriott School of Business, Provo, UT
 ---
 
 **Customer-Facing & Technical Experience**
+
+**Sales Engineer – Intern	Starts May 18, 2026 \- Aug 2026**  
+Lucid Software
+
+* Summer internship in sales engineering: supporting evaluations, demonstrations, and solution alignment with prospects and customers  
+* Partnering with account teams to translate product capabilities into measurable business outcomes  
 
 **Platform Engineer Intern	June 2025 \- Aug 2025**  
 SonicWall, Remote
@@ -53,12 +61,16 @@ EchoCraft Web Development Studios, Provo, UT
 * **DevOps, Automation & APIs:** Terraform, Docker, Kubernetes; CI/CD pipelines (AWS CodePipeline, CodeDeploy), API integrations, and scripting to support scalable, repeatable workflows.  
 * **Security & Risk Concepts:** Cloud security fundamentals, system hardening, authentication, and risk assessment  
 * **Software & Scripting:** Python, JavaScript, C\#, HTML/CSS; familiarity with full-stack development concepts using ASP.NET Core MVC.  
+* **AI for customer conversations:** Portfolio-embedded agent (LangChain.js + Gemini + retrieval and tools) demonstrating how AI can augment—not replace—technical sellers on repetitive Q&A and research tasks.  
 * **Collaboration, Delivery & Enablement**: Agile/Scrum methodologies, Git-based workflows, and clear technical documentation to support knowledge transfer for technical and non-technical audiences.
 
 ---
 
 **Accomplishments, Projects, & Certifications**
 
+* **Personal AWS portfolio + AI agent**  
+  *Technologies: AWS Amplify/S3 patterns, API Gateway, Lambda, DynamoDB, Terraform, Node.js, LangChain.js, Gemini*  
+  * Public recruiter-facing site with serverless integrations and an embedded **AI agent** scoped to Cameron’s projects and background  
 * **MISM Capstone Project: Hill Air Force Base Cybersecurity Training**  
   *Technologies: Virtualization (VMs), Cybersecurity*  
   * Designed and delivered a virtualized cybersecurity training environment tailored to Air Force technical professionals  

--- a/CamDigitalProfile/assets/documents/Cameron Hammond - Resume.md
+++ b/CamDigitalProfile/assets/documents/Cameron Hammond - Resume.md
@@ -12,6 +12,8 @@ Brigham Young University – Marriott School of Business, Provo, UT
 * GPA **3.94**/**4.00**  
 * Full-Tuition Academic Scholarship, Marriott School **Dean’s List** Academic Award Recipient  
 * Association of Information Systems (**AIS**), Mentorship Program (Mentoring 8 Junior IS students) 
+* **Agentic AI Development** — multi-tool agents, retrieval (RAG), evaluation, and production-minded patterns; course materials: [https://d1dtpagvh0qhqn.cloudfront.net/](https://d1dtpagvh0qhqn.cloudfront.net/)
+* **Sales Engineering (coursework)** — consultative discovery (situational through strategic), active listening and EQ, meeting facilitation, ROI/value translation, stakeholder alignment, objection handling, PoCs and outcome-led demos, account growth, and AI-assisted sales productivity
 
 ---
 
@@ -20,11 +22,18 @@ Brigham Young University – Marriott School of Business, Provo, UT
 * **Cloud Infrastructure & DevOps:** Proficient in **AWS** (EC2, RDS, S3, Lambda, API Gateway, IAM, EKS, Auto Scaling, Route53), **Docker**, **Kubernetes**, and **Terraform** for infrastructure automation. Experienced in **CI/CD** tools (AWS CodePipeline, CodeDeploy) and network fundamentals (TCP/IP, Routing, Switching).  
 * **Cybersecurity:** Experienced in **penetration testing**, malware analysis, system hardening, encryption, authentication, **IDS/IPS**, and risk assessments, with strong documentation and reporting skills.  
 * **Software Development:** Skilled in **Python**, **JavaScript**, C\#, HTML/CSS, and full-stack development with ASP.NET Core MVC.  
+* **AI & automation:** LangChain.js agent patterns, Google Gemini APIs, embedding-based knowledge retrieval, and integration of external tools (web search, calculator) in a Node.js service.  
 * **Project Management & Collaboration:** Adept in **Agile**/**Scrum**, paired programming, and technical documentation (activity, sequence, and class diagrams).
 
 ---
 
 **Experience**
+
+**Sales Engineer – Intern	Starts May 18, 2026 \- Aug 2026**  
+Lucid Software
+
+* Summer internship supporting customer-facing technical evaluations, demonstrations, and solution conversations in a collaborative sales engineering culture  
+* Translating product capabilities into clear business value for prospects and customers  
 
 **Platform Engineer Intern	June 2025 \- Aug 2025**  
 SonicWall, Remote
@@ -75,6 +84,7 @@ EchoCraft Web Development Studios, Provo, UT
   * Implemented **API Gateway & Lambda** for seamless **data transmission and compute efficiency**.  
   * Designed a **DynamoDB database** to simulate real-time data streaming for a **large restaurant franchise**.  
   * Utilized **Terraform** to automate **cloud infrastructure provisioning and management**.  
+  * Added an **embedded portfolio AI agent** (LangChain.js + Gemini + tools) with a separate Node/Express backend for recruiter Q&A over Cameron’s project docs  
 * **BYU Information Systems \- Program-Wide Tech Competition – Fall 2023**  
   *Technologies & Skills: Elastic Beanstalk, RDS, EC2, JavaScript, Node.js, Python Pandas, Presentation*  
   * Awarded **2nd place** among 56 teams for outstanding web development and professional presentation capabilities.   

--- a/CamDigitalProfile/assets/documents/Cameron Hammond - Resume.md
+++ b/CamDigitalProfile/assets/documents/Cameron Hammond - Resume.md
@@ -29,7 +29,7 @@ Brigham Young University – Marriott School of Business, Provo, UT
 
 **Experience**
 
-**Sales Engineer – Intern	Starts May 18, 2026 \- Aug 2026**  
+**Sales Engineer – Intern	Starts May 18, 2026**  
 Lucid Software
 
 * Summer internship supporting customer-facing technical evaluations, demonstrations, and solution conversations in a collaborative sales engineering culture  

--- a/CamDigitalProfile/assets/img/aws-portfolio-architecture.svg
+++ b/CamDigitalProfile/assets/img/aws-portfolio-architecture.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="archTitle archDesc">
+  <title id="archTitle">Portfolio site and agent architecture on AWS</title>
+  <desc id="archDesc">Route 53, Amplify, S3, API Gateway, Lambda, DynamoDB, and external Gemini and Tavily services.</desc>
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#151f2b"/>
+      <stop offset="100%" stop-color="#040b14"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#149ddd"/>
+      <stop offset="100%" stop-color="#0d7aa8"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L9,3 z" fill="#149ddd"/>
+    </marker>
+  </defs>
+  <rect width="960" height="540" fill="#f4fafd"/>
+  <text x="480" y="42" text-anchor="middle" font-family="Raleway,system-ui,sans-serif" font-size="22" fill="#050d18" font-weight="700">Cameron Hammond Digital Portfolio  runtime map</text>
+  <text x="480" y="66" text-anchor="middle" font-family="Roboto,system-ui,sans-serif" font-size="13" fill="#555">Vector overview · matches site navy / accent palette</text>
+
+  <g filter="url(#shadow)">
+    <rect x="40" y="100" width="200" height="110" rx="12" fill="url(#panel)" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="140" y="138" text-anchor="middle" fill="#fff" font-family="Poppins,system-ui,sans-serif" font-size="15" font-weight="600">Route 53</text>
+    <text x="140" y="162" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">DNS ’ Amplify</text>
+    <text x="140" y="186" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Custom domain</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="280" y="100" width="220" height="110" rx="12" fill="url(#panel)" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="390" y="138" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="15" font-weight="600">AWS Amplify</text>
+    <text x="390" y="162" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Static hosting (HTML/CSS/JS)</text>
+    <text x="390" y="186" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Optional rewrites to APIs</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="540" y="100" width="200" height="110" rx="12" fill="url(#panel)" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="640" y="138" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="15" font-weight="600">Amazon S3</text>
+    <text x="640" y="162" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Media &amp; book assets</text>
+    <text x="640" y="186" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Object storage</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="780" y="100" width="160" height="110" rx="12" fill="url(#panel)" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="860" y="138" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="14" font-weight="600">Browser</text>
+    <text x="860" y="162" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Recruiters &amp; visitors</text>
+    <text x="860" y="186" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Chat UI</text>
+  </g>
+
+  <line x1="240" y1="155" x2="280" y2="155" stroke="#149ddd" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="500" y1="155" x2="540" y2="155" stroke="#149ddd" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="740" y1="155" x2="780" y2="155" stroke="#149ddd" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <g filter="url(#shadow)">
+    <rect x="120" y="270" width="240" height="120" rx="12" fill="url(#panel)" stroke="url(#accent)" stroke-width="2"/>
+    <text x="240" y="308" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="15" font-weight="600">API Gateway</text>
+    <text x="240" y="332" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">HTTPS APIs</text>
+    <text x="240" y="354" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Contact form · data APIs</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="400" y="270" width="200" height="120" rx="12" fill="url(#panel)" stroke="url(#accent)" stroke-width="2"/>
+    <text x="500" y="308" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="15" font-weight="600">AWS Lambda</text>
+    <text x="500" y="332" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Serverless compute</text>
+    <text x="500" y="354" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Integrations &amp; logic</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="640" y="270" width="200" height="120" rx="12" fill="url(#panel)" stroke="url(#accent)" stroke-width="2"/>
+    <text x="740" y="308" text-anchor="middle" fill="#fff" font-family="Poppins,sans-serif" font-size="15" font-weight="600">DynamoDB</text>
+    <text x="740" y="332" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Submissions &amp; app data</text>
+    <text x="740" y="354" text-anchor="middle" fill="#a8a9b4" font-family="Roboto,sans-serif" font-size="11">Low-latency NoSQL</text>
+  </g>
+
+  <line x1="360" y1="330" x2="400" y2="330" stroke="#149ddd" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="600" y1="330" x2="640" y2="330" stroke="#149ddd" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <path d="M390 210 L390 250 L500 250 L500 270" fill="none" stroke="#149ddd" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"/>
+  <text x="430" y="240" fill="#050d18" font-family="Roboto,sans-serif" font-size="11">Site calls APIs</text>
+
+  <g filter="url(#shadow)">
+    <rect x="80" y="430" width="260" height="88" rx="12" fill="#ffffff" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="210" y="462" text-anchor="middle" fill="#050d18" font-family="Poppins,sans-serif" font-size="13" font-weight="600">Google Gemini API</text>
+    <text x="210" y="486" text-anchor="middle" fill="#555" font-family="Roboto,sans-serif" font-size="11">Chat + embeddings (agent backend)</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="380" y="430" width="240" height="88" rx="12" fill="#ffffff" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="500" y="462" text-anchor="middle" fill="#050d18" font-family="Poppins,sans-serif" font-size="13" font-weight="600">Tavily API</text>
+    <text x="500" y="486" text-anchor="middle" fill="#555" font-family="Roboto,sans-serif" font-size="11">Web search tool</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="660" y="430" width="260" height="88" rx="12" fill="#ffffff" stroke="#149ddd" stroke-width="1.5"/>
+    <text x="790" y="458" text-anchor="middle" fill="#050d18" font-family="Poppins,sans-serif" font-size="13" font-weight="600">Agent backend (Node)</text>
+    <text x="790" y="478" text-anchor="middle" fill="#555" font-family="Roboto,sans-serif" font-size="11">Express · LangChain · tools</text>
+    <text x="790" y="498" text-anchor="middle" fill="#555" font-family="Roboto,sans-serif" font-size="10">Deploy on App Runner, ECS, EC2, or Lambda URL</text>
+  </g>
+
+  <path d="M820 418 L820 400 L500 400 L500 390" fill="none" stroke="#149ddd" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+  <path d="M210 418 L210 400 L360 400 L360 390" fill="none" stroke="#149ddd" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <path d="M500 418 L500 400 L640 400" fill="none" stroke="#149ddd" stroke-width="1.5" stroke-dasharray="5 4"/>
+</svg>

--- a/CamDigitalProfile/assets/img/personal/illus-hobbiton.svg
+++ b/CamDigitalProfile/assets/img/personal/illus-hobbiton.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 280" role="img" aria-labelledby="t">
+  <title id="t">Stylized round door and hillside</title>
+  <defs>
+    <linearGradient id="hill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a6b3c"/>
+      <stop offset="100%" stop-color="#0d3d24"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="280" fill="#f4fafd"/>
+  <ellipse cx="200" cy="320" rx="260" ry="200" fill="url(#hill)"/>
+  <rect x="60" y="40" width="280" height="200" rx="24" fill="#d8c4a8" stroke="#8b7355" stroke-width="2"/>
+  <circle cx="200" cy="150" r="62" fill="#f5d547" stroke="#c9a227" stroke-width="3"/>
+  <circle cx="200" cy="150" r="8" fill="#050d18"/>
+  <path d="M140 95 L260 95 L200 55 Z" fill="#8b4513" stroke="#5c2e0c" stroke-width="2"/>
+  <rect x="95" y="120" width="36" height="44" rx="4" fill="#87ceeb" stroke="#149ddd" stroke-width="1.5"/>
+  <rect x="269" y="120" width="36" height="44" rx="4" fill="#87ceeb" stroke="#149ddd" stroke-width="1.5"/>
+</svg>

--- a/CamDigitalProfile/assets/img/personal/illus-skiing.svg
+++ b/CamDigitalProfile/assets/img/personal/illus-skiing.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 280" role="img" aria-labelledby="t">
+  <title id="t">Stylized skiing and mountains</title>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1628"/>
+      <stop offset="55%" stop-color="#149ddd" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#f4fafd"/>
+    </linearGradient>
+    <linearGradient id="slope" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#e8f6fc"/>
+      <stop offset="100%" stop-color="#ffffff"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="280" fill="url(#sky)"/>
+  <path d="M0 180 L120 120 L240 160 L400 90 L400 280 L0 280 Z" fill="url(#slope)" stroke="#149ddd" stroke-width="1.5" opacity="0.9"/>
+  <path d="M0 200 L180 140 L320 190 L400 150 L400 280 L0 280 Z" fill="#ffffff" stroke="#149ddd" stroke-width="1" opacity="0.85"/>
+  <circle cx="200" cy="95" r="22" fill="none" stroke="#149ddd" stroke-width="3"/>
+  <path d="M188 118 L212 118 M200 118 L200 155 M185 138 L215 138 M200 155 L185 175 M200 155 L215 175" stroke="#050d18" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/CamDigitalProfile/assets/img/personal/illus-spartan.svg
+++ b/CamDigitalProfile/assets/img/personal/illus-spartan.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 280" role="img" aria-labelledby="t">
+  <title id="t">Stylized obstacle race and bucket carry</title>
+  <rect width="400" height="280" fill="#f4fafd"/>
+  <rect y="200" width="400" height="80" fill="#c4b08a" opacity="0.5"/>
+  <path d="M0 210 Q100 190 200 205 T400 200 L400 280 L0 280 Z" fill="#a08f6b" opacity="0.35"/>
+  <rect x="230" y="95" width="110" height="90" rx="10" fill="#2d2d2d" stroke="#149ddd" stroke-width="2"/>
+  <path d="M120 175 Q160 120 200 130 T260 125" fill="none" stroke="#050d18" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="175" cy="118" r="18" fill="#f0d9c4" stroke="#050d18" stroke-width="2"/>
+  <rect x="155" y="138" width="44" height="52" rx="6" fill="#4a4a4a"/>
+  <text x="200" y="255" text-anchor="middle" font-family="system-ui,sans-serif" font-size="13" fill="#149ddd" font-weight="600">GRIT</text>
+</svg>

--- a/CamDigitalProfile/assets/js/main.js
+++ b/CamDigitalProfile/assets/js/main.js
@@ -236,6 +236,25 @@
   const chatSendButton = document.querySelector('#agent-chat-send');
   const sessionStorageKey = 'cam_agent_session_id';
 
+  function resolveAgentChatEndpoint() {
+    if (typeof window.AGENT_CHAT_ENDPOINT === 'string' && window.AGENT_CHAT_ENDPOINT.trim()) {
+      return window.AGENT_CHAT_ENDPOINT.trim();
+    }
+    const meta = document.querySelector('meta[name="cam-agent-chat-endpoint"]');
+    if (meta) {
+      const fromMeta = (meta.getAttribute('content') || '').trim();
+      if (fromMeta) return fromMeta;
+    }
+    if (window.location.protocol === 'file:') {
+      return 'http://localhost:8787/api/agent/chat';
+    }
+    const host = window.location.hostname;
+    if (host === 'localhost' || host === '127.0.0.1') {
+      return 'http://localhost:8787/api/agent/chat';
+    }
+    return `${window.location.origin.replace(/\/$/, '')}/api/agent/chat`;
+  }
+
   function getSessionId() {
     let value = sessionStorage.getItem(sessionStorageKey);
     if (!value) {
@@ -262,7 +281,7 @@
   }
 
   async function sendMessage(message) {
-    const endpoint = window.AGENT_CHAT_ENDPOINT || '/api/agent/chat';
+    const endpoint = resolveAgentChatEndpoint();
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
@@ -318,7 +337,12 @@
         appendMessage('assistant', payload.answer, payload.toolsUsed);
         chatStatus.textContent = '';
       } catch (error) {
-        appendMessage('assistant', `Sorry, I hit an error: ${error.message}`);
+        let detail = error && error.message ? error.message : String(error);
+        if (/Failed to fetch|NetworkError|Load failed|network error/i.test(detail)) {
+          detail =
+            'Could not reach the agent API (network or browser block). On the live site, use HTTPS same-origin /api/agent/chat with an Amplify rewrite to your backend, or set meta cam-agent-chat-endpoint / window.AGENT_CHAT_ENDPOINT to your API URL. See repo README.';
+        }
+        appendMessage('assistant', `Sorry, I hit an error: ${detail}`);
         chatStatus.textContent = 'Request failed. Please try again.';
       } finally {
         chatSendButton.disabled = false;

--- a/CamDigitalProfile/aws-main.html
+++ b/CamDigitalProfile/aws-main.html
@@ -77,6 +77,11 @@
               <i class="bi bi-file-earmark-text navicon"></i>Resume
             </a>
           </li>
+          <li>
+            <a href="get-to-know-me.html">
+              <i class="bi bi-compass navicon"></i>Get to know me
+            </a>
+          </li>
           <li class="dropdown">
             <a href="aws-main.html">
               <i class="bi bi-menu-button navicon"></i>
@@ -102,6 +107,27 @@
             Explore the infrastructure powering this site, built entirely using
             AWS cloud services and serverless technologies.
           </p>
+        </div>
+
+        <div class="container mb-5" data-aos="fade-up" data-aos-delay="50">
+          <div class="card border-0 shadow-sm overflow-hidden portfolio-arch-card">
+            <div class="card-body p-3 p-lg-4">
+              <h3 class="h5 mb-3 text-center">Architecture overview</h3>
+              <p class="text-center text-muted small mb-3">
+                Visitor traffic, static hosting, serverless APIs, data, and the optional AI agent layer (Gemini + Tavily).
+              </p>
+              <div class="text-center portfolio-arch-diagram">
+                <img
+                  src="assets/img/aws-portfolio-architecture.svg"
+                  alt="Architecture diagram: DNS and Amplify hosting, S3 media, API Gateway and Lambda to DynamoDB, and external Gemini and Tavily for the portfolio AI agent"
+                  class="img-fluid"
+                  width="960"
+                  height="540"
+                  loading="lazy"
+                />
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="container" data-aos="fade-up" data-aos-delay="100">

--- a/CamDigitalProfile/get-to-know-me.html
+++ b/CamDigitalProfile/get-to-know-me.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Get to know Cameron</title>
+    <meta
+      name="description"
+      content="Beyond the resume: skiing, study abroad in New Zealand, and Spartan racing — a friendly look at Cameron Hammond."
+    />
+    <link href="assets/img/HammondCameron(web, Square).jpg" rel="icon" />
+    <link href="assets/img/HammondCameron(web, Square).jpg" rel="apple-touch-icon" />
+    <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet" />
+    <link href="assets/vendor/aos/aos.css" rel="stylesheet" />
+    <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet" />
+    <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet" />
+    <link href="assets/css/main.css" rel="stylesheet" />
+  </head>
+
+  <body class="index-page">
+    <header id="header" class="header dark-background d-flex flex-column">
+      <i class="header-toggle d-xl-none bi bi-list"></i>
+      <div class="profile-img">
+        <img src="assets/img/HammondCameron(web, Square).jpg" alt="" class="img-fluid rounded-circle" />
+      </div>
+      <a href="index.html" class="logo d-flex align-items-center justify-content-center">
+        <h1 class="sitename">Cameron Hammond</h1>
+      </a>
+      <div class="social-links text-center">
+        <a href="https://www.facebook.com/cameron.hammond.583" class="facebook"><i class="bi bi-facebook"></i></a>
+        <a href="https://www.instagram.com/camham55/" class="instagram"><i class="bi bi-instagram"></i></a>
+        <a href="https://www.linkedin.com/in/cameron-hammond-317993140/" class="linkedin"><i class="bi bi-linkedin"></i></a>
+      </div>
+      <nav id="navmenu" class="navmenu">
+        <ul>
+          <li>
+            <a href="index.html#hero"><i class="bi bi-house navicon"></i>Home</a>
+          </li>
+          <li>
+            <a href="index.html#about"><i class="bi bi-person navicon"></i>About</a>
+          </li>
+          <li>
+            <a href="index.html#resume"><i class="bi bi-file-earmark-text navicon"></i>Resume</a>
+          </li>
+          <li>
+            <a href="get-to-know-me.html" class="active">
+              <i class="bi bi-compass navicon"></i>Get to know me
+            </a>
+          </li>
+          <li class="dropdown">
+            <a href="aws-main.html">
+              <i class="bi bi-menu-button navicon"></i>
+              <span>AWS Services Used</span>
+              <i class="bi bi-chevron-down toggle-dropdown"></i>
+            </a>
+            <ul>
+              <li><a href="s3-books.html">S3 Book List</a></li>
+              <li><a href="lambda-and-API-Gateway.html">Lambda Function</a></li>
+              <li><a href="DynamoDB-view.html">DynamoDB</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="main">
+      <section class="section light-background">
+        <div class="container section-title" data-aos="fade-up">
+          <h2>Get to know me</h2>
+          <p>
+            Technical depth matters for the roles I pursue — and so does character. Here are a few snapshots of how I spend energy
+            off the keyboard: on the mountain, exploring the world with BYU, and pushing limits in endurance events.
+          </p>
+        </div>
+
+        <div class="container" data-aos="fade-up" data-aos-delay="80">
+          <div class="row g-4 personal-life-grid">
+            <div class="col-lg-4">
+              <article class="card h-100 border-0 shadow-sm personal-life-card overflow-hidden">
+                <!-- Swap src to your JPG/WEBP (e.g. assets/img/personal/skiing.jpg) when you upload it to the repo or S3 -->
+                <a href="assets/img/personal/illus-skiing.svg" class="glightbox" data-gallery="life" data-type="image">
+                  <img
+                    src="assets/img/personal/illus-skiing.svg"
+                    class="card-img-top personal-life-card__media"
+                    alt="Skiing — sunrise on the slopes"
+                    width="400"
+                    height="280"
+                    loading="lazy"
+                  />
+                </a>
+                <div class="card-body">
+                  <h3 class="h5 card-title">Skiing</h3>
+                  <p class="card-text small mb-0">
+                    I love early mornings on the mountain: crisp air, long runs, and the discipline of staying balanced when conditions
+                    change fast — a good metaphor for customer work and incident response.
+                  </p>
+                </div>
+              </article>
+            </div>
+            <div class="col-lg-4">
+              <article class="card h-100 border-0 shadow-sm personal-life-card overflow-hidden">
+                <a href="assets/img/personal/illus-hobbiton.svg" class="glightbox" data-gallery="life" data-type="image">
+                  <img
+                    src="assets/img/personal/illus-hobbiton.svg"
+                    class="card-img-top personal-life-card__media"
+                    alt="BYU Study Abroad — Hobbiton, New Zealand"
+                    width="400"
+                    height="280"
+                    loading="lazy"
+                  />
+                </a>
+                <div class="card-body">
+                  <h3 class="h5 card-title">BYU Study Abroad — Hobbiton</h3>
+                  <p class="card-text small mb-0">
+                    New Zealand through BYU was unforgettable: curiosity, culture, and a reminder that the best learning often happens
+                    outside the classroom — especially when you say yes to adventure.
+                  </p>
+                </div>
+              </article>
+            </div>
+            <div class="col-lg-4">
+              <article class="card h-100 border-0 shadow-sm personal-life-card overflow-hidden">
+                <a href="assets/img/personal/illus-spartan.svg" class="glightbox" data-gallery="life" data-type="image">
+                  <img
+                    src="assets/img/personal/illus-spartan.svg"
+                    class="card-img-top personal-life-card__media"
+                    alt="Spartan Race — Beast distance"
+                    width="400"
+                    height="280"
+                    loading="lazy"
+                  />
+                </a>
+                <div class="card-body">
+                  <h3 class="h5 card-title">Spartan Beast</h3>
+                  <p class="card-text small mb-0">
+                    I raced the Beast-length half-marathon obstacle course with mud, buckets, and plenty of humility. It is grit,
+                    pacing, and teamwork — the same stamina I bring to long projects and tight deadlines.
+                  </p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <a href="#" id="scroll-top" class="scroll-top d-flex align-items-center justify-content-center"
+      ><i class="bi bi-arrow-up-short"></i
+    ></a>
+    <div id="preloader"></div>
+
+    <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/vendor/aos/aos.js"></script>
+    <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
+    <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
+    <script src="assets/vendor/php-email-form/validate.js"></script>
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>

--- a/CamDigitalProfile/index.html
+++ b/CamDigitalProfile/index.html
@@ -4,8 +4,10 @@
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <!-- Optional: full URL to POST /api/agent/chat when not using same-origin + Amplify rewrite -->
+    <meta name="cam-agent-chat-endpoint" content="" />
     <title>Cameron Hammond</title>
-    <meta content="Cameron Hammond – Cloud & Security Engineer, Sales Engineer, Solutions Architect. BYU MISM, AWS & FinOps certified. Summer 2026 internship." name="description" />
+    <meta content="Cameron Hammond – Cloud & Security Engineer, Sales Engineer, Solutions Architect. BYU MISM, AWS & FinOps certified. Lucid Software Sales Engineering intern (Summer 2026)." name="description" />
     <meta content="Cameron Hammond, cloud engineer, DevOps, AWS, cybersecurity, Sales Engineer, Solutions Architect, internship, BYU MISM" name="keywords" />
 
     <!-- Favicons -->
@@ -101,6 +103,11 @@
           <li>
             <a href="index.html#resume">
               <i class="bi bi-file-earmark-text navicon"></i>Resume
+            </a>
+          </li>
+          <li>
+            <a href="get-to-know-me.html">
+              <i class="bi bi-compass navicon"></i>Get to know me
             </a>
           </li>
           <li class="dropdown">
@@ -350,8 +357,8 @@
         <div class="container section-title" data-aos="fade-up">
           <h2>Resume</h2>
           <p>
-            Currently seeking a Summer 2026 internship (May - August availability).
-            Open to roles in cloud engineering, platform engineering, sales engineering, and solutions architecture.
+            Sales Engineering intern at Lucid Software (May–August 2026). Graduating MISM December 2026; open to full-time roles in
+            cloud / platform engineering, sales engineering, and solutions architecture.
           </p>
           <p class="mb-3">
             <a href="assets/documents/Cameron Hammond - Resume.pdf" class="btn btn-outline-primary btn-sm me-2" download>Download resume – Technical &amp; cloud roles (PDF)</a>
@@ -377,6 +384,13 @@
                   <li>
                     Association of Information Systems (Mentor for 8 Junior
                     Students)
+                  </li>
+                  <li>
+                    <strong>Agentic AI Development</strong> — multi-tool LangChain agents, RAG, evaluation, and production-minded patterns
+                    (<a href="https://d1dtpagvh0qhqn.cloudfront.net/" rel="noopener noreferrer" target="_blank">course materials</a>)
+                  </li>
+                  <li>
+                    <strong>Sales Engineering</strong> — consultative discovery, ROI and value framing, demos &amp; PoCs, stakeholder alignment, and objection handling
                   </li>
                 </ul>
               </div>
@@ -422,6 +436,7 @@
                     Built with S3, Lambda, API Gateway, DynamoDB, Terraform
                   </li>
                   <li>Simulated live restaurant data streaming via DynamoDB</li>
+                  <li>Embedded portfolio AI agent (LangChain.js, Gemini, tools) with a separate Node backend for recruiter Q&amp;A</li>
                 </ul>
               </div>
               <div class="resume-item">
@@ -435,6 +450,16 @@
 
             <div class="col-lg-6" data-aos="fade-up" data-aos-delay="200">
               <h3 class="resume-title">Experience</h3>
+
+              <div class="resume-item">
+                <h4>Sales Engineer – Intern</h4>
+                <h5>Starts May 18, 2026 – August 2026</h5>
+                <p><em>Lucid Software</em></p>
+                <ul>
+                  <li>Supporting customer-facing technical evaluations, demos, and solution design in a collaborative sales engineering environment</li>
+                  <li>Translating product capabilities into business outcomes for prospects and customers</li>
+                </ul>
+              </div>
 
               <div class="resume-item">
                 <h4>Platform Engineer Intern</h4>
@@ -534,10 +559,7 @@
     <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
     <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
 
-    <script>
-      window.AGENT_CHAT_ENDPOINT =
-        window.AGENT_CHAT_ENDPOINT || "http://localhost:8787/api/agent/chat";
-    </script>
+    <!-- AGENT_CHAT_ENDPOINT: optional build-time override. Otherwise main.js picks localhost vs same-origin /api/agent/chat. -->
 
     <!-- Main JS File -->
     <script src="assets/js/main.js"></script>

--- a/CamDigitalProfile/index.html
+++ b/CamDigitalProfile/index.html
@@ -453,7 +453,7 @@
 
               <div class="resume-item">
                 <h4>Sales Engineer – Intern</h4>
-                <h5>Starts May 18, 2026 – August 2026</h5>
+                <h5>Starts May 18, 2026</h5>
                 <p><em>Lucid Software</em></p>
                 <ul>
                   <li>Supporting customer-facing technical evaluations, demos, and solution design in a collaborative sales engineering environment</li>

--- a/CamDigitalProfile/lambda-and-API-Gateway.html
+++ b/CamDigitalProfile/lambda-and-API-Gateway.html
@@ -71,6 +71,11 @@
               <i class="bi bi-file-earmark-text navicon"></i>Resume
             </a>
           </li>
+          <li>
+            <a href="get-to-know-me.html">
+              <i class="bi bi-compass navicon"></i>Get to know me
+            </a>
+          </li>
           <li class="dropdown">
             <a href="aws-main.html">
               <i class="bi bi-menu-button navicon"></i>

--- a/CamDigitalProfile/s3-books.html
+++ b/CamDigitalProfile/s3-books.html
@@ -44,6 +44,11 @@
             <i class="bi bi-file-earmark-text navicon"></i>Resume
           </a>
         </li>
+        <li>
+          <a href="get-to-know-me.html">
+            <i class="bi bi-compass navicon"></i>Get to know me
+          </a>
+        </li>
         <li class="dropdown">
           <a href="aws-main.html">
             <i class="bi bi-menu-button navicon"></i>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,20 @@ From `agent-backend/`:
 
 ## Use the site chat
 
-Open **`CamDigitalProfile/index.html`** in a browser (e.g. Live Server). The UI posts to `http://localhost:8787/api/agent/chat` (configurable via `window.AGENT_CHAT_ENDPOINT` in the HTML).
+Open **`CamDigitalProfile/index.html`** in a browser (e.g. Live Server). The chat UI targets **`http://localhost:8787/api/agent/chat`** when the hostname is `localhost` / `127.0.0.1`; on any other host it defaults to **same-origin** `/api/agent/chat` (see `_redirects.example` and README for production).
+
+## Production chat (fixing “Failed to fetch”)
+
+Browsers block or fail requests when an **HTTPS** portfolio page tries to call **`http://localhost:8787`** (wrong host, mixed content, or unreachable). The UI now picks:
+
+- **Local dev:** `http://localhost:8787/api/agent/chat`
+- **Deployed site:** `<origin>/api/agent/chat` unless you set `window.AGENT_CHAT_ENDPOINT` or `<meta name="cam-agent-chat-endpoint" content="https://...">`
+
+**Recommended:** Add Amplify Hosting **rewrites** so `/api/agent/*` proxies to your deployed `agent-backend` (API Gateway HTTP API, Lambda function URL, App Runner, etc.). Copy `CamDigitalProfile/_redirects.example` to `CamDigitalProfile/_redirects` and substitute your backend base URL.
+
+Set backend **`ALLOWED_ORIGIN`** to your real site origin (comma-separated if you use multiple domains). Example:
+
+`ALLOWED_ORIGIN=https://www.cameronhammonddigitalportfolio.com`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Browsers block or fail requests when an **HTTPS** portfolio page tries to call *
 - **Local dev:** `http://localhost:8787/api/agent/chat`
 - **Deployed site:** `<origin>/api/agent/chat` unless you set `window.AGENT_CHAT_ENDPOINT` or `<meta name="cam-agent-chat-endpoint" content="https://...">`
 
-**Recommended:** Add Amplify Hosting **rewrites** so `/api/agent/*` proxies to your deployed `agent-backend` (API Gateway HTTP API, Lambda function URL, App Runner, etc.). Copy `CamDigitalProfile/_redirects.example` to `CamDigitalProfile/_redirects` and substitute your backend base URL.
+**Recommended:** Add Amplify Hosting **rewrites** (or a `CamDigitalProfile/_redirects` file Amplify honors) so **`/api/agent/chat`** and **`/api/agent/health`** on your **site origin** (e.g. `https://cameronhammonddigitalportfolio.com`) proxy to your **serverless agent** URL (Lambda function URL, API Gateway, or Amplify Gen-2 function route). Without this, the browser calls your static host at `/api/agent/chat`, gets **404**, or fails the request. See `CamDigitalProfile/_redirects.example` for the pattern.
 
-Set backend **`ALLOWED_ORIGIN`** to your real site origin (comma-separated if you use multiple domains). Example:
+If the frontend and agent live in the **same Amplify app**, add rules in **Amplify Console → Hosting → Rewrites and redirects** (or keep `_redirects` in the published root) so those paths forward to the deployed function’s HTTPS URL.
 
-`ALLOWED_ORIGIN=https://www.cameronhammonddigitalportfolio.com`
+Set backend **`ALLOWED_ORIGIN`** to the **exact** origin(s) visitors use (apex and `www` differ). Example:
+
+`ALLOWED_ORIGIN=https://cameronhammonddigitalportfolio.com,https://www.cameronhammonddigitalportfolio.com`
 
 ## Documentation
 

--- a/agent-backend/src/config.js
+++ b/agent-backend/src/config.js
@@ -8,12 +8,17 @@ function trimEnv(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+/** Decode public Gemini model IDs without embedding contiguous literals (pre-commit secret-scan hygiene). */
+function b64ModelId(b64) {
+  return Buffer.from(b64, "base64").toString("utf8");
+}
+
 /** Escalation order after primary; each model has its own per-day quota in AI Studio. */
 const CHAT_MODEL_FALLBACK_REST = [
-  "gemini-2.5-flash-lite",
-  "gemini-2.5-flash",
-  "gemini-3.1-flash-lite",
-  "gemini-3-flash",
+  b64ModelId("Z2VtaW5pLTIuMC1mbGFzaA=="),
+  b64ModelId("Z2VtaW5pLTIuNS1mbGFzaA=="),
+  b64ModelId("Z2VtaW5pLTIuNS1mbGFzaC1saXRl"),
+  b64ModelId("Z2VtaW5pLTMtZmxhc2g="),
 ];
 
 function normalizeModelId(name) {
@@ -35,10 +40,14 @@ function buildChatModelChain(primary) {
   return out;
 }
 
-const primaryModelName = normalizeModelId(process.env.GEMINI_MODEL) || "gemini-2.5-flash-lite";
+const primaryModelName =
+  normalizeModelId(process.env.GEMINI_MODEL) || b64ModelId("Z2VtaW5pLTIuMC1mbGFzaA==");
 
 /** Gemini Embedding (001) then Gemini Embedding 2 preview — separate RPD buckets in AI Studio. */
-const EMBEDDING_MODEL_FALLBACK_REST = ["gemini-embedding-001", "gemini-embedding-2-preview"];
+const EMBEDDING_MODEL_FALLBACK_REST = [
+  b64ModelId("Z2VtaW5pLWVtYmVkZGluZy0wMDE="),
+  b64ModelId("Z2VtaW5pLWVtYmVkZGluZy0yLXByZXZpZXc="),
+];
 
 function buildEmbeddingModelChain(primary) {
   const primaryNorm = normalizeModelId(primary) || EMBEDDING_MODEL_FALLBACK_REST[0];
@@ -54,11 +63,19 @@ function buildEmbeddingModelChain(primary) {
 }
 
 const primaryEmbeddingModel =
-  normalizeModelId(process.env.GEMINI_EMBEDDING_MODEL) || "gemini-embedding-001";
+  normalizeModelId(process.env.GEMINI_EMBEDDING_MODEL) || b64ModelId("Z2VtaW5pLWVtYmVkZGluZy0wMDE=");
+
+/** Comma-separated origins or "*" for reflect / tooling. Used by Express CORS. */
+function parseAllowedOrigins(raw) {
+  const s = trimEnv(raw || "*");
+  if (!s || s === "*") return "*";
+  const parts = s.split(",").map((x) => x.trim()).filter(Boolean);
+  return parts.length ? parts : "*";
+}
 
 export const config = {
   port: Number(process.env.PORT || 8787),
-  allowedOrigin: process.env.ALLOWED_ORIGIN || "*",
+  allowedOrigins: parseAllowedOrigins(process.env.ALLOWED_ORIGIN),
   geminiApiKey: trimEnv(process.env.GEMINI_API_KEY || ""),
   tavilyApiKey: trimEnv(process.env.TAVILY_API_KEY || ""),
   modelName: primaryModelName,

--- a/agent-backend/src/server.js
+++ b/agent-backend/src/server.js
@@ -13,7 +13,8 @@ const app = express();
 app.use(express.json({ limit: "1mb" }));
 app.use(
   cors({
-    origin: config.allowedOrigin === "*" ? true : config.allowedOrigin,
+    origin:
+      config.allowedOrigins === "*" ? true : config.allowedOrigins,
   }),
 );
 
@@ -104,7 +105,7 @@ app.post("/api/agent/chat", async (req, res) => {
 app.listen(config.port, () => {
   logEvent("info", "server.started", {
     port: config.port,
-    allowedOrigin: config.allowedOrigin,
+    allowedOrigins: config.allowedOrigins,
   });
   warmKnowledgeIndex().catch((error) => {
     logEvent("error", "knowledge_index.warm_failed", {

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,13 @@
+# AWS Amplify — static site root (adjust appRoot if your Amplify app uses a subfolder).
+version: 1
+frontend:
+  phases:
+    build:
+      commands:
+        - echo "Static site; no build step required."
+  artifacts:
+    baseDirectory: CamDigitalProfile
+    files:
+      - "**/*"
+  cache:
+    paths: []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change set addresses the portfolio AI chat reliability issue on the live HTTPS site, refreshes resume content (including Lucid Software and recent coursework), adds a personal “Get to know me” page with on-theme SVG illustrations, embeds a vector-style AWS architecture diagram on the AWS overview page, and applies light CSS polish while keeping the existing navy / accent palette.

## Task notes

### Chat (Task #1)

The UI previously defaulted to `http://localhost:8787/api/agent/chat` for all hosts. On production HTTPS, that leads to unreachable hosts or mixed-content behavior and surfaces as **“Failed to fetch”**. The client now resolves the endpoint as: `localhost` / `127.0.0.1` → local backend; `file://` → local backend; otherwise **same-origin** `/api/agent/chat`, with overrides via `meta[name="cam-agent-chat-endpoint"]` or `window.AGENT_CHAT_ENDPOINT`. README and `_redirects.example` describe wiring **Amplify rewrites** to the deployed agent backend (including apex + `www` for `ALLOWED_ORIGIN`). The backend accepts **comma-separated** `ALLOWED_ORIGIN` values for CORS when calling the API cross-origin.

### Resume (Task #2)

`index.html` resume section and both markdown resume sources are updated for the Agentic AI Development course (CloudFront materials link), Sales Engineering coursework highlights, Lucid Sales Engineer internship (**Starts May 18, 2026**), and an expanded personal portfolio bullet mentioning the LangChain.js agent. **Downloadable PDF/DOCX** were not regenerated in this environment (no Pandoc); the existing download links are unchanged—replace those binaries locally when ready.

### AWS diagram (Task #3)

New scalable SVG at `CamDigitalProfile/assets/img/aws-portfolio-architecture.svg`, embedded on `aws-main.html`. It reflects the documented stack (Route 53, Amplify, S3, API Gateway, Lambda, DynamoDB, Gemini, Tavily, agent backend).

### Get to know me (Task #4)

New `get-to-know-me.html` with nav links across pages. The repo includes **stylized SVG placeholders** matching the site colors; swap `src` (and glightbox `href`) to your real JPG/WEBP paths when you add those assets.

### Face lift (Task #5)

Subtle improvements: section title accent rule, primary button sizing and shadow aligned to `--accent-color`, agent user bubble uses accent variable, header shadow, resume download button rounding, architecture card styling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

