### PR TITLE
fix(amplify): monorepo amplify.yml for CamDigitalProfile builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Set backend **`ALLOWED_ORIGIN`** to the **exact** origin(s) visitors use (apex a
 
 `ALLOWED_ORIGIN=https://cameronhammonddigitalportfolio.com,https://www.cameronhammonddigitalportfolio.com`
 
+### Amplify build: monorepo `amplify.yml`
+
+If the Amplify app uses a monorepo app root (e.g. **`AMPLIFY_MONOREPO_APP_ROOT=CamDigitalProfile`**), root **`amplify.yml`** must use an **`applications`** list with **`appRoot`**, not a top-level **`frontend:`** block. Otherwise Amplify fails with **`CustomerError: Monorepo spec provided without "applications" key`**. See [monorepo configuration](https://docs.aws.amazon.com/amplify/latest/userguide/monorepo-configuration.html).
+
 ## Documentation
 
 - **Runbook & env:** [CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md](CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md)  

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,13 +1,16 @@
-# AWS Amplify — static site root (adjust appRoot if your Amplify app uses a subfolder).
+# AWS Amplify Hosting — monorepo build spec (required when the app is connected as a monorepo).
+# AMPLIFY_MONOREPO_APP_ROOT in the Amplify console must match appRoot (e.g. CamDigitalProfile).
 version: 1
-frontend:
-  phases:
-    build:
-      commands:
-        - echo "Static site; no build step required."
-  artifacts:
-    baseDirectory: CamDigitalProfile
-    files:
-      - "**/*"
-  cache:
-    paths: []
+applications:
+  - appRoot: CamDigitalProfile
+    frontend:
+      phases:
+        build:
+          commands:
+            - echo "Static site; no build step required."
+      artifacts:
+        baseDirectory: .
+        files:
+          - "**/*"
+      cache:
+        paths: []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Amplify build failed with:

`CustomerError: Monorepo spec provided without "applications" key`

Your app uses **`AMPLIFY_MONOREPO_APP_ROOT=CamDigitalProfile`**. In that mode, root `amplify.yml` must declare **`applications`** with **`appRoot`**, not a single-app `frontend:` block at the top level.

## Change

- Replace `amplify.yml` with the monorepo shape: `applications[0].appRoot: CamDigitalProfile`, `artifacts.baseDirectory: .` (artifacts are published from that folder).
- Document the requirement in `README.md`.

## After merge

Merge to `main`, let Amplify redeploy, and confirm the build passes. No change needed to your env var screenshot value **`CamDigitalProfile`** — it already matches `appRoot`.

**Security note:** If API keys appeared in any shared screenshot or chat, rotate them in Google AI Studio / Tavily and update Amplify env vars only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

