### PR TITLE
fix(chat): Amplify build injects agent URL; clearer 404 handling

### DIFF
--- a/CamDigitalProfile/assets/js/main.js
+++ b/CamDigitalProfile/assets/js/main.js
@@ -298,8 +298,17 @@
       try {
         payload = JSON.parse(rawBody);
       } catch (_error) {
+        const host = window.location.hostname;
+        const isLocal = host === 'localhost' || host === '127.0.0.1';
+        const hint404 =
+          response.status === 404 && !isLocal
+            ? ` No JSON from ${endpoint.split('?')[0]} — usually missing Amplify rewrite to your agent, or set Amplify build env PORTFOLIO_AGENT_CHAT_URL to your full chat HTTPS URL (see README).`
+            : '';
+        const hintLocal = isLocal
+          ? ' For local dev, run agent-backend on port 8787 (npm run dev in agent-backend/).'
+          : '';
         payload = {
-          error: `Backend returned non-JSON response (status ${response.status}). Check that agent-backend is running on http://localhost:8787.`
+          error: `Backend returned non-JSON response (HTTP ${response.status}).${hint404}${hintLocal}`
         };
       }
     }

--- a/CamDigitalProfile/index.html
+++ b/CamDigitalProfile/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <!-- Optional: full URL to POST /api/agent/chat when not using same-origin + Amplify rewrite -->
+    <!-- Production: set Amplify env PORTFOLIO_AGENT_CHAT_URL (full https URL to …/api/agent/chat); build injects it here. -->
     <meta name="cam-agent-chat-endpoint" content="" />
     <title>Cameron Hammond</title>
     <meta content="Cameron Hammond – Cloud & Security Engineer, Sales Engineer, Solutions Architect. BYU MISM, AWS & FinOps certified. Lucid Software Sales Engineering intern (Summer 2026)." name="description" />

--- a/CamDigitalProfile/scripts/inject-agent-endpoint.py
+++ b/CamDigitalProfile/scripts/inject-agent-endpoint.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Amplify build helper: inject PORTFOLIO_AGENT_CHAT_URL into index.html meta.
+
+Set in Amplify → Environment variables (build time), e.g.:
+  PORTFOLIO_AGENT_CHAT_URL=https://xxxx.lambda-url.us-east-1.on.aws/api/agent/chat
+
+Full URL including path. If unset, leaves meta empty (same-origin /api/agent/chat).
+"""
+from __future__ import annotations
+
+import html
+import os
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    url = (os.environ.get("PORTFOLIO_AGENT_CHAT_URL") or "").strip()
+    here = pathlib.Path(__file__).resolve().parent
+    index = here.parent / "index.html"
+    if not index.is_file():
+        print(f"inject-agent-endpoint: missing {index}", file=sys.stderr)
+        return 1
+
+    text = index.read_text(encoding="utf-8")
+    if not url:
+        print("inject-agent-endpoint: PORTFOLIO_AGENT_CHAT_URL not set; leaving cam-agent-chat-endpoint empty.")
+        return 0
+
+    esc = html.escape(url, quote=True)
+    pattern = r'(<meta\s+name="cam-agent-chat-endpoint"\s+content=")[^"]*("\s*/>)'
+
+    def repl(m: re.Match[str]) -> str:
+        return m.group(1) + esc + m.group(2)
+
+    new_text, n = re.subn(pattern, repl, text, count=1)
+    if n != 1:
+        print("inject-agent-endpoint: could not find <meta name=\"cam-agent-chat-endpoint\" ...> in index.html", file=sys.stderr)
+        return 1
+
+    index.write_text(new_text, encoding="utf-8")
+    print("inject-agent-endpoint: wrote cam-agent-chat-endpoint into index.html")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Set backend **`ALLOWED_ORIGIN`** to the **exact** origin(s) visitors use (apex a
 
 If the Amplify app uses a monorepo app root (e.g. **`AMPLIFY_MONOREPO_APP_ROOT=CamDigitalProfile`**), root **`amplify.yml`** must use an **`applications`** list with **`appRoot`**, not a top-level **`frontend:`** block. Otherwise Amplify fails with **`CustomerError: Monorepo spec provided without "applications" key`**. See [monorepo configuration](https://docs.aws.amazon.com/amplify/latest/userguide/monorepo-configuration.html).
 
+### Point the live site at your agent (404 on `/api/agent/chat`)
+
+If you **do not** use same-origin **rewrites** to your Lambda, the browser posts to `https://<your-domain>/api/agent/chat` and Amplify returns **404** (HTML), which shows as a chat error.
+
+**Option A — Amplify build env (simplest with this repo):** In Amplify → **Environment variables**, add **`PORTFOLIO_AGENT_CHAT_URL`** for **All branches** (available at build time). Value must be the **full HTTPS URL** to the chat route, for example:
+
+`https://xxxxxxxx.lambda-url.us-east-1.on.aws/api/agent/chat`
+
+On each build, `scripts/inject-agent-endpoint.py` writes that URL into **`CamDigitalProfile/index.html`** `meta name="cam-agent-chat-endpoint"`, which the UI reads before calling `fetch`.
+
+**Option B — Hosting rewrites:** Keep `meta` empty and add **Rewrites and redirects** (or `_redirects`) so `/api/agent/chat` proxies to the same URL as above. See `CamDigitalProfile/_redirects.example`.
+
 ## Documentation
 
 - **Runbook & env:** [CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md](CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md)  

--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,12 @@ applications:
       phases:
         build:
           commands:
-            - echo "Static site; no build step required."
+            - echo "Publish static site; optional agent URL injection."
+            - |
+                set -e
+                APPROOT="${AMPLIFY_MONOREPO_APP_ROOT:-CamDigitalProfile}"
+                cd "$APPROOT"
+                python3 scripts/inject-agent-endpoint.py
       artifacts:
         baseDirectory: .
         files:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Diagnosis

The deployed site calls **`/api/agent/chat`** on the **same origin** (your Amplify static URL). With **no rewrite** to your serverless agent, Amplify serves an **HTML 404 page**. The chat UI tries to parse that as JSON and showed a **misleading** message mentioning `localhost:8787`.

## Fix

1. **Amplify build** runs `CamDigitalProfile/scripts/inject-agent-endpoint.py`, which reads **`PORTFOLIO_AGENT_CHAT_URL`** (Amplify environment variable) and writes it into **`index.html`** `meta name="cam-agent-chat-endpoint"` so the browser posts to your **real** Lambda / function URL.

2. **`main.js`** — clearer error text when the response is non-JSON (especially HTTP 404 on production).

3. **`README.md`** — documents **Option A** (`PORTFOLIO_AGENT_CHAT_URL`) vs **Option B** (Hosting rewrites / `_redirects`).

## What you must do in AWS after merge

In **Amplify → Environment variables**, add **`PORTFOLIO_AGENT_CHAT_URL`** (all branches) with the **full HTTPS URL** to your agent chat endpoint, e.g.:

`https://xxxxxxxx.lambda-url.us-east-1.on.aws/api/agent/chat`

Redeploy. Ensure agent **`ALLOWED_ORIGIN`** includes your site origin(s).

If you prefer same-origin URLs instead, skip this env var and configure **Hosting → Rewrites** per `_redirects.example`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

