### PR TITLE
fix(amplify): monorepo build cwd — do not nest cd CamDigitalProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ On each build, `scripts/inject-agent-endpoint.py` writes that URL into **`CamDig
 
 **Option B — Hosting rewrites:** Keep `meta` empty and add **Rewrites and redirects** (or `_redirects`) so `/api/agent/chat` proxies to the same URL as above. See `CamDigitalProfile/_redirects.example`.
 
+The build step locates `scripts/inject-agent-endpoint.py` whether the job’s **current directory is already `CamDigitalProfile`** (common for `appRoot`) or the **repository root** (then it `cd`s into that folder).
+
 ## Documentation
 
 - **Runbook & env:** [CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md](CamDigitalProfile/AI_Projects/docs/AGENT-BACKEND-RUNBOOK.md)  

--- a/amplify.yml
+++ b/amplify.yml
@@ -10,9 +10,20 @@ applications:
             - echo "Publish static site; optional agent URL injection."
             - |
                 set -e
-                APPROOT="${AMPLIFY_MONOREPO_APP_ROOT:-CamDigitalProfile}"
-                cd "$APPROOT"
-                python3 scripts/inject-agent-endpoint.py
+                # Monorepo: Amplify often already uses appRoot as cwd; repo clone may be at repo root.
+                if [ -f scripts/inject-agent-endpoint.py ]; then
+                  echo "inject-agent-endpoint: cwd=$(pwd) (app root)"
+                  python3 scripts/inject-agent-endpoint.py
+                elif [ -f CamDigitalProfile/scripts/inject-agent-endpoint.py ]; then
+                  cd CamDigitalProfile
+                  echo "inject-agent-endpoint: cwd=$(pwd) (entered CamDigitalProfile)"
+                  python3 scripts/inject-agent-endpoint.py
+                else
+                  echo "inject-agent-endpoint: could not find script"
+                  ls -la
+                  ls -la CamDigitalProfile 2>/dev/null || true
+                  exit 1
+                fi
       artifacts:
         baseDirectory: .
         files:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cause

Amplify monorepo builds with `appRoot: CamDigitalProfile` often start the **frontend build phase with `cwd` already inside `CamDigitalProfile`**. The previous `amplify.yml` always ran `cd CamDigitalProfile`, which looked for **`CamDigitalProfile/CamDigitalProfile`** and failed:

`cd: CamDigitalProfile: No such file or directory`

## Fix

Run `scripts/inject-agent-endpoint.py` from the current directory **if** `scripts/inject-agent-endpoint.py` exists; otherwise `cd CamDigitalProfile` from the repo root and run it.

README notes this behavior.

## Note on log line 21

`Failed to set up process.env.secrets` is a separate Amplify/SSM warning and is unrelated to the `cd` failure; if secrets are optional for this static frontend build you can ignore unless you rely on SSM-injected env at build time.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-447ee42e-a2e7-4532-8f9f-92c436c0ec91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

